### PR TITLE
chore: remove specific reviewers and assignees from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,7 @@ updates:
       - "dependencies"
       - "backend"
       - "go"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
-
+    
   # Root Go dependencies (if any)
   - package-ecosystem: "gomod"
     directory: "/"
@@ -41,10 +37,6 @@ updates:
     labels:
       - "dependencies"
       - "go"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
 
   # Frontend npm dependencies
   # Monitors package.json and package-lock.json for Node.js updates
@@ -63,10 +55,6 @@ updates:
       - "dependencies"
       - "frontend"
       - "npm"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
     # Group minor and patch updates to reduce PR noise
     groups:
       frontend-minor:
@@ -98,10 +86,6 @@ updates:
       - "dependencies"
       - "docker"
       - "backend"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
@@ -118,10 +102,6 @@ updates:
       - "dependencies"
       - "docker"
       - "frontend"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
 
   # Docker Compose configurations
   # Monitors docker-compose.yml files for service image updates
@@ -140,10 +120,6 @@ updates:
       - "dependencies"
       - "docker"
       - "infrastructure"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"
 
   # GitHub Actions workflows
   # Monitors .github/workflows for action version updates
@@ -162,7 +138,3 @@ updates:
       - "dependencies"
       - "github-actions"
       - "ci/cd"
-    reviewers:
-      - "nipuna-perera"
-    assignees:
-      - "nipuna-perera"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration file by removing the default reviewer and assignee (`nipuna-perera`) from all dependency update rules. This change ensures that dependency update pull requests will no longer be automatically assigned to or reviewed by a specific individual.

Key changes:

### Removal of default reviewer and assignee:
* Removed `nipuna-perera` as the default reviewer and assignee for Go dependencies. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L24-L27) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L44-L47)
* Removed `nipuna-perera` as the default reviewer and assignee for npm dependencies.
* Removed `nipuna-perera` as the default reviewer and assignee for Docker dependencies (both backend and frontend). [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L101-L104) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L121-L124)
* Removed `nipuna-perera` as the default reviewer and assignee for infrastructure-related Docker dependencies.
* Removed `nipuna-perera` as the default reviewer and assignee for GitHub Actions workflow updates.